### PR TITLE
Cleanup deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.10</version>
+        <version>4.12</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
+        <artifactId>mockito-core</artifactId>
         <version>1.9.5</version>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
Switched mockito-all dependency to mockito-core.
Upgraded junit to 4.12. This contains some generics fixes.

I will create another pull request for assertj-core.


Note: Do not depend on mockito-all in maven projects. That jar contains all the transitive dependencies inlined - but with the same old package names.