### PR TITLE
Remove oss-parent, update plugins, add bootstrap site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.2</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.8</version>
+        <version>2.8.1</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <!-- using oss-parent to release on Sonatype OSS reposirories that are synced with maven central -->
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>9</version>
-  </parent>
+
   <groupId>org.assertj</groupId>
   <artifactId>assertj-parent-pom</artifactId>
   <version>1.3.8-SNAPSHOT</version>
@@ -78,7 +73,7 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-  
+
   <profiles>
     <profile>
       <id>release</id>
@@ -390,7 +385,7 @@
         </executions>
       </plugin>
     </plugins>
-  </build>  
+  </build>
   <reporting>
     <plugins>
       <plugin>


### PR DESCRIPTION
oss-parent is now deprecated per sonar.  Everything else needed to run builds was already present in this pom so no other related changes.  

Updated all other plugins listed to most recent versions.

Added basic bootstrap site using fluido plugin