### PR TITLE
license-maven-plugin: use SLASHSTAR_STYLE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,9 @@
           <excludes>
             <exclude>src/ide-support/**/*.*</exclude>
           </excludes>
+          <mapping>
+            <java>SLASHSTAR_STYLE</java>
+          </mapping>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
It looks like SLASHSTAR_STYLE is more common for licence or copyright headers in the java world than javadoc style.
Actually, intellij displays a warning for javadoc style license headers.  
