### PR TITLE
Use maven-enforcer-plugin instead of prerequisites to check the maven…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,10 +52,6 @@
     </repository>
   </distributionManagement>
 
-  <prerequisites>
-    <maven>3.5.0</maven>
-  </prerequisites>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -258,6 +254,26 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M2</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.5.0,)</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <!-- This plugin is retired and should be removed.  M2e handles eclipse now entirely -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
… version (prerequisites should only be used by maven plugins).

versions-maven-plugin `2.7` understands the enforcer rule, so there is no reason to stick to prerequisites.