### PR TITLE
Update jacoco-maven-plugin to version 0.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.2</version>
+          <version>0.8.3</version>
           <executions>
             <execution>
               <id>prepare-agent</id>


### PR DESCRIPTION
JaCoCo now officially supports Java 11 and has eperimental support for Java 13.
see https://github.com/jacoco/jacoco/releases/tag/v0.8.3 for details.